### PR TITLE
Security hardening: firmware host/path validation, raw-write danger gate, secret file perms

### DIFF
--- a/crates/oura-cli/src/main.rs
+++ b/crates/oura-cli/src/main.rs
@@ -183,12 +183,27 @@ fn generate_key() -> Result<[u8; 16]> {
 
 /// Persist a key as hex with owner-only permissions.
 fn save_key(path: &Path, key: &[u8; 16]) -> Result<()> {
-    std::fs::write(path, format!("{}\n", hex::encode(key)))
-        .with_context(|| format!("writing key file {}", path.display()))?;
+    let contents = format!("{}\n", hex::encode(key));
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        use std::io::Write;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+        // Create with 0600 from the start so the key is never briefly world-readable.
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+            .with_context(|| format!("writing key file {}", path.display()))?;
+        f.write_all(contents.as_bytes())?;
+        // mode() above only applies on create; tighten an already-existing file too.
+        f.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, contents)
+            .with_context(|| format!("writing key file {}", path.display()))?;
     }
     Ok(())
 }

--- a/crates/oura-store/src/storage.rs
+++ b/crates/oura-store/src/storage.rs
@@ -68,7 +68,15 @@ pub struct Store {
 impl Store {
     /// Open (creating if needed) a database at `path` and ensure the schema.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
         let conn = Connection::open(path)?;
+        // Health data + device identifiers are sensitive; keep the DB owner-only.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+                .map_err(|e| crate::error::Error::Storage(e.to_string()))?;
+        }
         conn.execute_batch(SCHEMA)?;
         Ok(Self { conn })
     }

--- a/tools/oura_firmware_download.py
+++ b/tools/oura_firmware_download.py
@@ -41,8 +41,24 @@ import os
 import sys
 import urllib.error
 import urllib.request
+from urllib.parse import urlparse
 
 API_BASE = "https://api.ouraring.com"
+API_HOST = "api.ouraring.com"
+
+
+def _is_api_url(url: str) -> bool:
+    """True only for https://api.ouraring.com (exact host) -- not lookalikes."""
+    p = urlparse(url)
+    return p.scheme == "https" and p.hostname == API_HOST
+
+
+def _safe_filename(manifest: dict) -> str:
+    """Basename-only output filename so a hostile manifest can't escape out_dir."""
+    fname = os.path.basename(manifest.get("filename") or "")
+    if fname in ("", ".", ".."):
+        fname = f"{manifest.get('type','fw')}_{manifest.get('version','0')}.bin"
+    return fname
 # A plausible app UA; the real one comes from EndpointKt.getUserAgent(appConfig).
 USER_AGENT = "okhttp/4.12.0"
 
@@ -85,14 +101,13 @@ def download_image(manifest: dict, out_dir: str, token: str | None) -> str:
     url = manifest["url"]
     # The manifest URL is usually a presigned CDN link (no auth). Send the
     # bearer only if it's back on api.ouraring.com.
-    use_token = token if url.startswith(API_BASE) else None
+    use_token = token if _is_api_url(url) else None
     status, _, data = _req(url, token=use_token, accept="application/octet-stream")
     if status != 200:
         raise SystemExit(f"download {url} -> HTTP {status}")
 
     os.makedirs(out_dir, exist_ok=True)
-    fname = manifest.get("filename") or f"{manifest.get('type','fw')}_{manifest.get('version','0')}.bin"
-    path = os.path.join(out_dir, fname)
+    path = os.path.join(out_dir, _safe_filename(manifest))
 
     # Integrity checks against the manifest.
     problems = []

--- a/tools/oura_firmware_download.py
+++ b/tools/oura_firmware_download.py
@@ -55,9 +55,15 @@ def _is_api_url(url: str) -> bool:
 
 def _safe_filename(manifest: dict) -> str:
     """Basename-only output filename so a hostile manifest can't escape out_dir."""
-    fname = os.path.basename(manifest.get("filename") or "")
+    def basename_only(value: object) -> str:
+        fname = os.path.basename(str(value or "").replace("\\", "/"))
+        return "" if fname in ("", ".", "..") else fname
+
+    fname = basename_only(manifest.get("filename"))
     if fname in ("", ".", ".."):
-        fname = f"{manifest.get('type','fw')}_{manifest.get('version','0')}.bin"
+        fname = basename_only(f"{manifest.get('type','fw')}_{manifest.get('version','0')}.bin")
+    if fname in ("", ".", ".."):
+        fname = "fw_0.bin"
     return fname
 # A plausible app UA; the real one comes from EndpointKt.getUserAgent(appConfig).
 USER_AGENT = "okhttp/4.12.0"

--- a/tools/oura_protocol.py
+++ b/tools/oura_protocol.py
@@ -532,8 +532,11 @@ def write_capture(path: Optional[Path], record: dict) -> None:
     if not path:
         return
     path.parent.mkdir(parents=True, exist_ok=True)
+    new = not path.exists()
     with path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(record, sort_keys=True) + "\n")
+    if new:
+        os.chmod(path, 0o600)  # captures hold serials/MAC-derived ids
 
 
 def load_key(args: argparse.Namespace) -> Optional[bytes]:
@@ -589,6 +592,10 @@ async def transact(client: BleakClient, request: bytes, listen_seconds: float, c
         write_capture(capture, record)
         print(f"notification command={name} sender={sender} {describe_packet(payload)}")
 
+    # set_auth_key writes are packet 0x24 || <16-byte ring auth key>; that key
+    # is a secret, so never persist or print the raw bytes.
+    logged_hex = "24<redacted-auth-key>" if name == "set_auth_key" else request.hex()
+
     await client.start_notify(OURA_NOTIFY, on_notify)
     write_capture(
         capture,
@@ -597,10 +604,10 @@ async def transact(client: BleakClient, request: bytes, listen_seconds: float, c
             "command": name,
             "direction": "write",
             "uuid": OURA_WRITE,
-            "hex": request.hex(),
+            "hex": logged_hex,
         },
     )
-    print(f"write command={name} uuid={OURA_WRITE} hex={request.hex()}")
+    print(f"write command={name} uuid={OURA_WRITE} hex={logged_hex}")
     await client.write_gatt_char(OURA_WRITE, request, response=True)
     await asyncio.sleep(listen_seconds)
     await client.stop_notify(OURA_NOTIFY)
@@ -676,8 +683,10 @@ async def main() -> None:
     for name, _, safety in expanded:
         if safety == "state" and not args.include_state:
             raise SystemExit(f"{name} is state-changing; pass --include-state")
-        if safety == "danger" and not args.include_danger:
-            raise SystemExit(f"{name} is dangerous; pass --include-danger")
+        # Raw hex: frames are unclassified -- they can encode any opcode incl.
+        # dangerous ones, so gate them behind --include-danger too.
+        if safety in ("danger", "unknown") and not args.include_danger:
+            raise SystemExit(f"{name} is unclassified/dangerous; pass --include-danger")
 
     key = load_key(args)
     if args.generate_auth_key:
@@ -704,7 +713,7 @@ async def main() -> None:
             if key is None:
                 key = secrets.token_bytes(16)
                 save_key(args.auth_key_file, key)
-                print(f"generated_auth_key file={args.auth_key_file} hex={key.hex()}")
+                print(f"generated_auth_key file={args.auth_key_file} (hex written to file, 0600)")
             await set_auth_key(client, key, args.listen_seconds, capture)
         for name, request, _ in expanded:
             try:

--- a/tools/oura_token_sniff.py
+++ b/tools/oura_token_sniff.py
@@ -10,6 +10,7 @@ to tools/oura_tokens.txt (gitignored).
 """
 
 import json
+import os
 import re
 from pathlib import Path
 
@@ -28,8 +29,11 @@ def _emit(label: str, value: str, host: str) -> None:
         return
     _seen.add(key)
     ctx.log.alert(f"[OURA TOKEN] {host} {label}: {value}")
+    new = not OUT.exists()
     with OUT.open("a") as f:
         f.write(f"{host}\t{label}\t{value}\n")
+    if new:
+        os.chmod(OUT, 0o600)  # file holds full account tokens
 
 
 def _scan_json(obj, host: str, path: str = "") -> None:

--- a/tools/test_firmware_download.py
+++ b/tools/test_firmware_download.py
@@ -1,0 +1,35 @@
+"""Security regression checks for the firmware downloader (Codex findings 6 & 7).
+
+Run: python3 tools/test_firmware_download.py
+"""
+import os
+
+from oura_firmware_download import _is_api_url, _safe_filename
+
+
+def test_host_check():
+    # Real host gets the token.
+    assert _is_api_url("https://api.ouraring.com/api/v2/file/x")
+    # Lookalikes / downgrades do NOT (would leak the bearer otherwise).
+    assert not _is_api_url("https://api.ouraring.com.evil.example/fw.bin")
+    assert not _is_api_url("http://api.ouraring.com/fw.bin")          # not https
+    assert not _is_api_url("https://evil.example/api.ouraring.com")    # host in path
+    assert not _is_api_url("https://api-ouraring.com/fw.bin")
+
+
+def test_filename_containment():
+    out = "/safe/out"
+    for hostile in ("../../outside.txt", "/tmp/absolute.bin", "..", ".", "", "a/b/c.bin"):
+        path = os.path.join(out, _safe_filename({"filename": hostile}))
+        # Resolved path must stay directly under out.
+        assert os.path.dirname(os.path.normpath(path)) == out, (hostile, path)
+    # A normal filename is preserved.
+    assert _safe_filename({"filename": "fw.bin"}) == "fw.bin"
+    # Missing filename falls back to a synthesized basename.
+    assert _safe_filename({"type": "firmware_oreo", "version": "3.4.3"}) == "firmware_oreo_3.4.3.bin"
+
+
+if __name__ == "__main__":
+    test_host_check()
+    test_filename_containment()
+    print("ok")

--- a/tools/test_firmware_download.py
+++ b/tools/test_firmware_download.py
@@ -27,6 +27,7 @@ def test_filename_containment():
     assert _safe_filename({"filename": "fw.bin"}) == "fw.bin"
     # Missing filename falls back to a synthesized basename.
     assert _safe_filename({"type": "firmware_oreo", "version": "3.4.3"}) == "firmware_oreo_3.4.3.bin"
+    assert _safe_filename({"filename": "", "type": "../../outside", "version": "1"}) == "outside_1.bin"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi! While exploring this repo I ran a security review over the BLE client and the Python research tooling and found a handful of trust-boundary issues. They're all fixed here, each with the rationale below. No behavior changes for normal use.

## Fixes

**Real input-validation bugs**
- **Bearer token could leak to a lookalike host** (`tools/oura_firmware_download.py`). `use_token = token if url.startswith(API_BASE)` treats a string prefix as host validation, so `https://api.ouraring.com.evil.example/fw.bin` passes and would receive the account bearer. Now parses the URL and requires `scheme == https` and `hostname == api.ouraring.com` exactly.
- **Manifest filename path traversal** (`tools/oura_firmware_download.py`). `os.path.join(out_dir, manifest["filename"])` lets `../../x` or `/etc/x` escape `--out`. Now reduced to a basename (with `.`/`..`/empty fallback).

**Safety-gate bypass**
- **Raw `hex:` writes skipped the danger gate** (`tools/oura_protocol.py`). Named destructive commands require `--include-danger`, but a `hex:` frame was tagged `unknown` and slipped past the gate, so an arbitrary frame could encode the same dangerous opcode unguarded. Unclassified frames now require `--include-danger` too.

**Secret/data exposure & file permissions**
- Redact the 16-byte ring auth key from `set_auth_key` write logs and JSONL captures; stop printing generated keys to stdout (they're already saved to a 0600 file); create capture files `0600` (`tools/oura_protocol.py`).
- Create `oura_tokens.txt` `0600` — it holds full account tokens (`tools/oura_token_sniff.py`).
- Create the auth key file `0600` at creation via `OpenOptions`, closing the brief world-readable window between write and chmod (`crates/oura-cli/src/main.rs`).
- Create the SQLite DB `0600` — it holds raw health data + device identifiers (`crates/oura-store/src/storage.rs`).

## Tests
Adds `tools/test_firmware_download.py` covering the host-validation and path-traversal logic. The Rust workspace builds and `cargo test --workspace` passes (33 tests); `cargo audit` reports 0 vulnerabilities.

Happy to split this into smaller PRs or adjust anything if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)