### PR TITLE
docs: clarify Oura models aren't shipped; fix stale hypnogram status

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,13 @@ engine and a set of on-device PyTorch models (the same `.pt` we run here), then
 uploaded; the cloud only stores and syncs them back. So they're reproducible
 offline. The one genuine cloud-only step is **workout auto-classification**
 (`POST /api/activity-tagging/v2`). See
-[`docs/data-recovery-map.md`](docs/data-recovery-map.md) and
-[`docs/algorithms/README.md`](docs/algorithms/README.md).
+[`docs/data-recovery-map.md`](docs/data-recovery-map.md),
+[`docs/algorithms/README.md`](docs/algorithms/README.md), and
+[`docs/model-runners.md`](docs/model-runners.md) for what runs.
+
+> **Those PyTorch models are Oura's proprietary IP and are NOT included in this
+> repo** (gitignored under `notes/models/`). The runners reference them by path; you
+> decrypt and supply your own locally. Nothing model-related is committed or pushed.
 
 ## Repository map
 

--- a/docs/activity-model-runner.md
+++ b/docs/activity-model-runner.md
@@ -1,5 +1,9 @@
 # Running Oura's activity-detection model on our data
 
+> **Models are not included in this repo.** The decrypted `.pt` files are Oura's
+> proprietary IP; they are **not committed** (gitignored under `notes/models/`).
+> Run these against your own locally-decrypted copies.
+
 `tools/run_activity_model.py` feeds our stored ring events into Oura's decrypted
 TorchScript `automatic_activity_detection_3_1_11.pt` and prints detected activity
 segments — **no raw IMU / RData needed**, it runs on the windowed signals we

--- a/docs/algorithms/README.md
+++ b/docs/algorithms/README.md
@@ -13,6 +13,12 @@ addresses refer to functions in the decompiled `libappecore.so` (see
 `native-decoder.md` for the Ghidra method). Per-metric detail files are added as
 each is ported; this index is the status table.
 
+> **Models are not included in this repo.** Where the table says a metric runs via
+> a decrypted PyTorch model (`tools/run_*.py`), those `.pt` files are Oura's
+> proprietary IP and are **not committed** (gitignored under `notes/models/`) —
+> you supply your own locally-decrypted copies. See
+> [`docs/model-runners.md`](../model-runners.md).
+
 ## Status
 
 | Metric | ecore source | Rust impl | Status |
@@ -30,7 +36,7 @@ each is ported; this index is the status table.
 | Activity score + contributors | `get_activity_score_raw @ 0x1d5788` (per-contributor pw-interp, Y=[0,25,95,100]); combiner `@ 0x1d781c` | - | ◐ contributor curves + X-tables recovered; final-combiner divisor ambiguous - needs careful re-read |
 | Activity targets / cals / MET | `actinfo_target_to_cal @ 0x1cd2c8`, `actinfo_update_5_min_classification @ 0x1cd640` | `oura-analysis::metabolic` | ◐ VO2max/BMR/steps→m ported+tested; MET-class ordering + calorie/step regression best-effort |
 | Cycle prediction / tracking | `cycle_prediction_calculate @ 0x1e2864`, `cycle_tracking_calculate @ 0x1e4244` | - | ◐ day-type thresholds + 0.18–0.30 sine band recovered; fit_sin/sine_from_range unresolved - deferred |
-| **Sleep hypnogram (staging)** | SleepNet PyTorch model (`sleepstaging_2_6_0.pt.enc`) - not in ecore | - | ❌ blocked: AES-256-GCM decryption RE'd, but the key is **server-delivered** (see [sleepnet.md](sleepnet.md)) |
+| **Sleep hypnogram (staging)** | SleepNet PyTorch model - not in ecore | `tools/run_sleep_model.py`, `tools/run_models.py bdi` | ✅ **decrypted + running**: we produce a DEEP/LIGHT/REM/WAKE hypnogram offline with the decrypted `sleepnet_moonstone_1_2_0` (and `sleepnet_bdi_0_4_0` for apnea). The model key was extracted, so decryption is no longer blocked. `sleepstaging_2_6_0` itself won't load (needs a custom op `oura_ops::oura_create_windows` our torch runtime lacks) — moonstone covers staging. See [model-runners.md](../model-runners.md) |
 
 ## Device vs cloud (corrected)
 

--- a/docs/cva-cardiovascular-age.md
+++ b/docs/cva-cardiovascular-age.md
@@ -1,5 +1,9 @@
 # Cardiovascular age from raw PPG (`cva_ppg` → `cva_raw_ppg_data` → CVA model)
 
+> **Models are not included in this repo.** The decrypted `cva_2_1_0.pt` (and every
+> other `.pt`) is Oura's proprietary IP; it is **not committed** (gitignored under
+> `notes/models/`). Run this against your own locally-decrypted copy.
+
 When the **`cva_ppg`** feature (`CAP_CVA_PPG_SAMPLER`, id `0x0d`) is enabled, the
 ring records short raw-PPG bursts overnight and emits them as **`cva_raw_ppg_data`**
 events (BLE tag **`0x81`**). This is the raw photoplethysmography waveform the

--- a/docs/model-runners.md
+++ b/docs/model-runners.md
@@ -1,5 +1,10 @@
 # Running Oura's on-device models on your synced data
 
+> **Models are not included in this repo.** The decrypted `.pt` files are Oura's
+> proprietary IP and are **not committed or pushed** (gitignored under
+> `notes/models/`). The runners reference them by path; you supply your own
+> locally-decrypted copies.
+
 The ring ships Oura's analysis as encrypted on-device PyTorch models. Once
 decrypted locally (into the gitignored `notes/models/`), several of them run on
 the signals we already sync into `oura.db`. This page indexes the runners and what

--- a/docs/spo2-calibration.md
+++ b/docs/spo2-calibration.md
@@ -1,5 +1,10 @@
 # SpO2: turning the ring's R-ratio into a percentage
 
+> This path uses **no model file** — just the small calibration constants below
+> (read from the decompiled app). Unlike the activity/sleep/CVA runners, it needs
+> none of Oura's proprietary `.pt` models (which are never committed — see
+> [`docs/model-runners.md`](model-runners.md)).
+
 The ring's **`spo2_r_pi_event`** (tag `0x8b`) carries, per sample, an `r`
 (ratio-of-ratios) and a perfusion index (`pi`) — **not** an SpO2 percentage. Two
 paths convert it:


### PR DESCRIPTION
## Summary
Makes it explicit across all model-related docs that the decrypted `.pt` model files are **Oura's proprietary IP and are not committed/pushed** (gitignored under `notes/models/`; you supply your own locally-decrypted copies).

- Adds a consistent notice to: README, `docs/model-runners.md`, `docs/activity-model-runner.md`, `docs/cva-cardiovascular-age.md`, `docs/algorithms/README.md`, `docs/spo2-calibration.md` (SpO2 noted as needing no model — just documented coefficients).
- Fixes the stale **sleep-hypnogram** row in `docs/algorithms/README.md`: it said "blocked: key server-delivered", but the key was extracted, so it's decrypted and running offline via `sleepnet_moonstone_1_2_0` (+ `sleepnet_bdi` for apnea). `sleepstaging_2_6_0` itself won't load (missing custom op) — moonstone covers staging.

Docs only — no code, no model weights.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes; no code, runners, or secrets altered.
> 
> **Overview**
> Documentation-only PR that makes **Oura's decrypted `.pt` models are not found nowhere in the repo** (gitignored `notes/models/`; users supply local copies) across README, `docs/model-runners.md`, activity/CVA runner pages, and `docs/algorithms/README.md`. **`docs/spo2-calibration.md`** now states the SpO2 path needs **no** model file—only calibration constants—and points readers at `model-runners.md`.
> 
> The **sleep hypnogram** row in `docs/algorithms/README.md` is corrected from “blocked (server-delivered key)” to **decrypted and runnable offline** via `tools/run_sleep_model.py` / moonstone (+ BDI for apnea), with a note that `sleepstaging_2_6_0` still fails on a missing custom torch op while moonstone covers staging. README also links **`docs/model-runners.md`** in the intro paragraph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 212e49ede695cbdc908634ba17434fa293268495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->