### PR TITLE
Windows BLE bond + secure key storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -81,7 +81,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -335,7 +335,7 @@ dependencies = [
  "futures-util",
  "libc",
  "libdbus-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -362,7 +362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -479,6 +479,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -679,7 +690,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -688,7 +699,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -763,6 +774,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "getrandom",
  "hex",
  "oura-link",
  "oura-protocol",
@@ -770,6 +782,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -785,6 +798,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "windows",
 ]
 
 [[package]]
@@ -1021,7 +1035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1110,7 +1124,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1323,7 +1337,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1436,11 +1450,36 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1451,6 +1490,54 @@ checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xml"

--- a/crates/oura-cli/Cargo.toml
+++ b/crates/oura-cli/Cargo.toml
@@ -17,6 +17,17 @@ oura-store = { path = "../oura-store" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
+getrandom = "0.2"
 hex = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+    "Win32_System_Threading",
+] }

--- a/crates/oura-cli/src/main.rs
+++ b/crates/oura-cli/src/main.rs
@@ -1,7 +1,6 @@
 //! `oura` — a command-line client that reads data directly from an Oura ring over
 //! BLE, with no Oura cloud account. See `--help` for subcommands.
 
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -159,9 +158,8 @@ fn load_key(path: &Option<PathBuf>) -> Result<Option<[u8; 16]>> {
 
 /// Generate a random 16-byte auth key from the OS CSPRNG.
 fn generate_key() -> Result<[u8; 16]> {
-    let mut file = std::fs::File::open("/dev/urandom").context("opening /dev/urandom")?;
     let mut key = [0u8; 16];
-    file.read_exact(&mut key).context("reading random bytes")?;
+    getrandom::getrandom(&mut key).map_err(|e| anyhow!("reading OS CSPRNG: {e}"))?;
     Ok(key)
 }
 
@@ -184,10 +182,230 @@ fn save_key(path: &Path, key: &[u8; 16]) -> Result<()> {
         // mode() above only applies on create; tighten an already-existing file too.
         f.set_permissions(std::fs::Permissions::from_mode(0o600))?;
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
     {
-        std::fs::write(path, contents)
+        save_key_windows(path, contents.as_bytes())
             .with_context(|| format!("writing key file {}", path.display()))?;
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = contents;
+        return Err(anyhow!(
+            "secure key storage is not implemented on this platform"
+        ));
+    }
+    Ok(())
+}
+
+/// Create `path` with a current-user-only DACL *before* writing any key bytes,
+/// then verify the resulting ACL. Never logs key material.
+#[cfg(windows)]
+fn save_key_windows(path: &Path, contents: &[u8]) -> Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, GetLastError, LocalFree, ERROR_SUCCESS, FALSE, HANDLE, INVALID_HANDLE_VALUE,
+    };
+    use windows_sys::Win32::Security::Authorization::{
+        ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW,
+        GetNamedSecurityInfoW, SDDL_REVISION_1, SE_FILE_OBJECT,
+    };
+    use windows_sys::Win32::Security::{
+        EqualSid, GetAce, GetTokenInformation, TokenUser, ACCESS_ALLOWED_ACE, ACL,
+        DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID, SECURITY_ATTRIBUTES, TOKEN_QUERY,
+        TOKEN_USER,
+    };
+    // Win32 ACCESS_ALLOWED_ACE_TYPE
+    const ACCESS_ALLOWED_ACE_TYPE: u8 = 0;
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, DeleteFileW, MoveFileExW, WriteFile, CREATE_NEW, FILE_ATTRIBUTE_NORMAL,
+        FILE_GENERIC_WRITE, FILE_SHARE_NONE, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    fn wide(path: &Path) -> Vec<u16> {
+        path.as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    unsafe fn last_error(context: &str) -> anyhow::Error {
+        anyhow!("{context} (Win32 error {})", GetLastError())
+    }
+
+    unsafe {
+        // Current-user SID -> SDDL: protected DACL, only that user, full access.
+        let mut token: HANDLE = std::ptr::null_mut();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == FALSE {
+            return Err(last_error("OpenProcessToken"));
+        }
+        let mut needed = 0u32;
+        GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut needed);
+        // TOKEN_USER contains a pointer; allocate with pointer alignment, not u8.
+        let words = (needed as usize).div_ceil(std::mem::size_of::<u64>()).max(1);
+        let mut buf = vec![0u64; words];
+        let buf_bytes = (words * std::mem::size_of::<u64>()) as u32;
+        if GetTokenInformation(
+            token,
+            TokenUser,
+            buf.as_mut_ptr().cast(),
+            buf_bytes,
+            &mut needed,
+        ) == FALSE
+        {
+            CloseHandle(token);
+            return Err(last_error("GetTokenInformation(TokenUser)"));
+        }
+        CloseHandle(token);
+        let token_user = &*(buf.as_ptr() as *const TOKEN_USER);
+        let user_sid: PSID = token_user.User.Sid;
+
+        let mut sid_string: windows_sys::core::PWSTR = std::ptr::null_mut();
+        if ConvertSidToStringSidW(user_sid, &mut sid_string) == FALSE {
+            return Err(last_error("ConvertSidToStringSidW"));
+        }
+        let sid_len = (0..).take_while(|&i| *sid_string.add(i) != 0).count();
+        let sid_rust = String::from_utf16_lossy(std::slice::from_raw_parts(sid_string, sid_len));
+        LocalFree(sid_string.cast());
+
+        // D:P = protect against inherited ACEs; A;;FA = allow file-all to this SID only.
+        let sddl = format!("D:P(A;;FA;;;{sid_rust})");
+        let sddl_wide: Vec<u16> = sddl.encode_utf16().chain(std::iter::once(0)).collect();
+        let mut sd: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+        if ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl_wide.as_ptr(),
+            SDDL_REVISION_1,
+            &mut sd,
+            std::ptr::null_mut(),
+        ) == FALSE
+        {
+            return Err(last_error(
+                "ConvertStringSecurityDescriptorToSecurityDescriptorW",
+            ));
+        }
+
+        let path_w = wide(path);
+        // Write+verify a unique sibling temp file first so an existing key is
+        // never deleted until the replacement is fully validated, and concurrent
+        // pair processes cannot share one deterministic temp path.
+        let tmp_name = format!(
+            "{}.{}-{}.tmp",
+            path.file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("oura.key"),
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+        let tmp_path = path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(tmp_name);
+        let tmp_w = wide(&tmp_path);
+        if tmp_path.exists() {
+            let _ = DeleteFileW(tmp_w.as_ptr());
+        }
+
+        let sa = SECURITY_ATTRIBUTES {
+            nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: sd,
+            bInheritHandle: FALSE,
+        };
+        let handle = CreateFileW(
+            tmp_w.as_ptr(),
+            FILE_GENERIC_WRITE,
+            FILE_SHARE_NONE,
+            &sa,
+            CREATE_NEW,
+            FILE_ATTRIBUTE_NORMAL,
+            std::ptr::null_mut(),
+        );
+        LocalFree(sd.cast());
+        if handle == INVALID_HANDLE_VALUE {
+            return Err(last_error("CreateFileW temp key with user-only DACL"));
+        }
+
+        let mut written = 0u32;
+        let write_ok = WriteFile(
+            handle,
+            contents.as_ptr(),
+            contents.len() as u32,
+            &mut written,
+            std::ptr::null_mut(),
+        );
+        CloseHandle(handle);
+        if write_ok == FALSE || written as usize != contents.len() {
+            let _ = DeleteFileW(tmp_w.as_ptr());
+            return Err(last_error("WriteFile temp key bytes"));
+        }
+
+        // Verify: DACL present, exactly one ACCESS_ALLOWED ACE, SID == current user.
+        let mut owner: PSID = std::ptr::null_mut();
+        let mut group: PSID = std::ptr::null_mut();
+        let mut dacl: *mut ACL = std::ptr::null_mut();
+        let mut sacl: *mut ACL = std::ptr::null_mut();
+        let mut sd_out: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+        let status = GetNamedSecurityInfoW(
+            tmp_w.as_ptr(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            &mut owner,
+            &mut group,
+            &mut dacl,
+            &mut sacl,
+            &mut sd_out,
+        );
+        if status != ERROR_SUCCESS {
+            let _ = DeleteFileW(tmp_w.as_ptr());
+            return Err(anyhow!(
+                "GetNamedSecurityInfoW failed after temp key write (Win32 error {status})"
+            ));
+        }
+        let verify = (|| -> Result<()> {
+            if dacl.is_null() {
+                return Err(anyhow!("temp key file DACL missing after create"));
+            }
+            let ace_count = (*dacl).AceCount;
+            if ace_count != 1 {
+                return Err(anyhow!(
+                    "temp key file DACL AceCount={ace_count}, expected 1 (current user only)"
+                ));
+            }
+            let mut ace: *mut core::ffi::c_void = std::ptr::null_mut();
+            if GetAce(dacl, 0, &mut ace) == FALSE {
+                return Err(last_error("GetAce"));
+            }
+            let ace_hdr = ace as *const windows_sys::Win32::Security::ACE_HEADER;
+            if (*ace_hdr).AceType != ACCESS_ALLOWED_ACE_TYPE {
+                return Err(anyhow!("temp key file DACL ACE is not ACCESS_ALLOWED"));
+            }
+            let allowed = ace as *const ACCESS_ALLOWED_ACE;
+            let ace_sid = &(*allowed).SidStart as *const u32 as PSID;
+            if EqualSid(ace_sid, user_sid) == FALSE {
+                return Err(anyhow!(
+                    "temp key file DACL ACE SID does not match current user"
+                ));
+            }
+            Ok(())
+        })();
+        LocalFree(sd_out.cast());
+        if let Err(e) = verify {
+            let _ = DeleteFileW(tmp_w.as_ptr());
+            return Err(e);
+        }
+
+        // Atomically replace the destination; on failure the old key (if any) remains.
+        if MoveFileExW(
+            tmp_w.as_ptr(),
+            path_w.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        ) == FALSE
+        {
+            let _ = DeleteFileW(tmp_w.as_ptr());
+            return Err(last_error("MoveFileExW temp key into place"));
+        }
     }
     Ok(())
 }
@@ -484,8 +702,10 @@ async fn cmd_pair(cli: &Cli) -> Result<()> {
         .set_auth_key(&key)
         .await
         .context("set_auth_key failed (is the ring factory-reset / removed from the app?)")?;
+    // Print the key path (needed to use the ring later). Default filenames may
+    // include the serial; that is intentional for discoverability.
     println!(
-        "Installed {} auth key on {serial}; saved to {}",
+        "Installed {} auth key; saved to {}",
         if reused { "existing" } else { "new" },
         out.display()
     );
@@ -1108,4 +1328,129 @@ async fn cmd_events(cli: &Cli) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Independently inspect a key file DACL (used by tests; not the write path's
+/// self-check). Returns Ok(()) only when AceCount==1 ACCESS_ALLOWED for the
+/// current process user.
+#[cfg(all(test, windows))]
+fn assert_key_file_user_only_dacl(path: &Path) -> Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, GetLastError, LocalFree, ERROR_SUCCESS, FALSE, HANDLE,
+    };
+    use windows_sys::Win32::Security::Authorization::{GetNamedSecurityInfoW, SE_FILE_OBJECT};
+    use windows_sys::Win32::Security::{
+        EqualSid, GetAce, GetTokenInformation, TokenUser, ACCESS_ALLOWED_ACE, ACE_HEADER, ACL,
+        DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID, TOKEN_QUERY, TOKEN_USER,
+    };
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    const ACCESS_ALLOWED_ACE_TYPE: u8 = 0;
+
+    let path_w: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    unsafe {
+        let mut token: HANDLE = std::ptr::null_mut();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == FALSE {
+            return Err(anyhow!("OpenProcessToken (Win32 {})", GetLastError()));
+        }
+        let mut needed = 0u32;
+        GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut needed);
+        let words = (needed as usize).div_ceil(std::mem::size_of::<u64>()).max(1);
+        let mut buf = vec![0u64; words];
+        let buf_bytes = (words * std::mem::size_of::<u64>()) as u32;
+        if GetTokenInformation(
+            token,
+            TokenUser,
+            buf.as_mut_ptr().cast(),
+            buf_bytes,
+            &mut needed,
+        ) == FALSE
+        {
+            CloseHandle(token);
+            return Err(anyhow!(
+                "GetTokenInformation (Win32 {})",
+                GetLastError()
+            ));
+        }
+        CloseHandle(token);
+        let token_user = &*(buf.as_ptr() as *const TOKEN_USER);
+        let user_sid: PSID = token_user.User.Sid;
+
+        let mut owner: PSID = std::ptr::null_mut();
+        let mut group: PSID = std::ptr::null_mut();
+        let mut dacl: *mut ACL = std::ptr::null_mut();
+        let mut sacl: *mut ACL = std::ptr::null_mut();
+        let mut sd_out: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+        let status = GetNamedSecurityInfoW(
+            path_w.as_ptr(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            &mut owner,
+            &mut group,
+            &mut dacl,
+            &mut sacl,
+            &mut sd_out,
+        );
+        if status != ERROR_SUCCESS {
+            return Err(anyhow!("GetNamedSecurityInfoW failed ({status})"));
+        }
+        let result = (|| -> Result<()> {
+            if dacl.is_null() {
+                return Err(anyhow!("DACL missing on key file"));
+            }
+            let ace_count = (*dacl).AceCount;
+            if ace_count != 1 {
+                return Err(anyhow!("AceCount={ace_count}, expected 1"));
+            }
+            let mut ace: *mut core::ffi::c_void = std::ptr::null_mut();
+            if GetAce(dacl, 0, &mut ace) == FALSE {
+                return Err(anyhow!("GetAce failed (Win32 {})", GetLastError()));
+            }
+            let ace_hdr = ace as *const ACE_HEADER;
+            if (*ace_hdr).AceType != ACCESS_ALLOWED_ACE_TYPE {
+                return Err(anyhow!("ACE is not ACCESS_ALLOWED"));
+            }
+            let allowed = ace as *const ACCESS_ALLOWED_ACE;
+            let ace_sid = &(*allowed).SidStart as *const u32 as PSID;
+            if EqualSid(ace_sid, user_sid) == FALSE {
+                return Err(anyhow!("ACE SID does not match current user"));
+            }
+            Ok(())
+        })();
+        LocalFree(sd_out.cast());
+        result
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_key_storage_tests {
+    use super::{assert_key_file_user_only_dacl, save_key};
+
+    #[test]
+    fn save_key_creates_user_only_dacl_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "oura-key-acl-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("test.key");
+        let key = [7u8; 16];
+        save_key(&path, &key).expect("save_key");
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(text.trim(), hex::encode(key));
+        assert_key_file_user_only_dacl(&path).expect("independent DACL check");
+        save_key(&path, &key).expect("save_key overwrite");
+        assert_key_file_user_only_dacl(&path).expect("independent DACL check after overwrite");
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
 }

--- a/crates/oura-link/Cargo.toml
+++ b/crates/oura-link/Cargo.toml
@@ -19,6 +19,13 @@ futures = "0.3"
 # can build for iOS, where CoreBluetooth implements the `Transport` trait instead.
 btleplug = { version = "0.11", optional = true }
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.61", optional = true, features = [
+    "Devices_Bluetooth",
+    "Devices_Enumeration",
+    "Foundation",
+] }
+
 [features]
 default = ["ble"]
-ble = ["dep:btleplug"]
+ble = ["dep:btleplug", "dep:windows"]

--- a/crates/oura-link/src/ble.rs
+++ b/crates/oura-link/src/ble.rs
@@ -1,13 +1,16 @@
 //! `btleplug`-backed [`Transport`] for real rings (feature `ble`).
 
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use btleplug::api::{
-    Central, CharPropFlags, Characteristic, Manager as _, Peripheral as _, ScanFilter, WriteType,
+    Central, CharPropFlags, Characteristic, Manager as _, Peripheral as _, PeripheralProperties,
+    ScanFilter, WriteType,
 };
 use btleplug::platform::{Manager, Peripheral};
 use futures::StreamExt;
 use tokio::sync::broadcast;
+use uuid::Uuid;
 
 use crate::error::{Error, Result};
 use crate::transport::Transport;
@@ -17,6 +20,9 @@ use oura_protocol::protocol;
 /// imposes no deadline itself, so without this a ring that won't complete the GATT
 /// handshake hangs the caller forever.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Bluetooth SIG company identifier for Oura Health Oy (NRF: `<0x02B2>`).
+const OURA_COMPANY_ID: u16 = 0x02B2;
 
 /// A ring discovered while scanning.
 #[derive(Clone, Debug)]
@@ -47,15 +53,58 @@ async fn first_adapter() -> Result<btleplug::platform::Adapter> {
         .ok_or_else(|| Error::Ble("no Bluetooth adapter found".into()))
 }
 
-/// Scan for Oura rings advertising the service, filtered by case-insensitive name
-/// substring. Returns candidates sorted by signal strength (strongest first).
+/// True if advertisement has Oura-specific evidence (not merely a name substring).
+///
+/// Accepts either:
+/// - Oura GATT service UUID in the adv service list, or
+/// - Oura company id `0x02B2` in manufacturer data
+///
+/// Name alone is intentionally insufficient: on Windows, `connect` may trigger
+/// an auto-accepted OS BLE bond before GATT validation, so a coincidental
+/// `"oura"` substring in an unrelated device name must not select a candidate.
+/// WinRT often omits incomplete 128-bit service lists from `props.services`
+/// even when NRF shows them; manufacturer data is the reliable fallback there.
+fn is_oura_advertisement(
+    services: &[Uuid],
+    manufacturer_data: &HashMap<u16, Vec<u8>>,
+    _local_name: &str,
+) -> bool {
+    services.contains(&protocol::OURA_SERVICE)
+        || manufacturer_data.contains_key(&OURA_COMPANY_ID)
+}
+
+/// Apply the user `--name` substring filter.
+///
+/// Empty needle matches everything. On Windows the local name is often missing
+/// even when the ring advertises one; if the user asked for the default `"Oura"`
+/// (or another `oura…` needle), allow empty-named candidates that already passed
+/// [`is_oura_advertisement`].
+fn name_filter_matches(name_contains: &str, local_name: &str) -> bool {
+    let needle = name_contains.trim().to_lowercase();
+    if needle.is_empty() {
+        return true;
+    }
+    let name = local_name.to_lowercase();
+    if name.contains(&needle) {
+        return true;
+    }
+    name.is_empty() && needle.starts_with("oura")
+}
+
+fn props_match_oura(props: &PeripheralProperties, name_contains: &str) -> bool {
+    let name = props.local_name.as_deref().unwrap_or("");
+    is_oura_advertisement(&props.services, &props.manufacturer_data, name)
+        && name_filter_matches(name_contains, name)
+}
+
+/// Scan for Oura rings. Uses an unfiltered OS scan then classifies advertisements
+/// in-process so platforms that drop incomplete service UUID lists (notably
+/// WinRT) still surface rings. Returns candidates sorted by RSSI (strongest first).
 pub async fn scan(name_contains: &str, timeout: Duration) -> Result<Vec<Discovered>> {
     let adapter = first_adapter().await?;
-    adapter
-        .start_scan(ScanFilter {
-            services: vec![protocol::OURA_SERVICE],
-        })
-        .await?;
+    // Do not pass `services: [OURA_SERVICE]` to the OS watcher: on Windows that
+    // filter can hide ads that only carry an *incomplete* 128-bit UUID list.
+    adapter.start_scan(ScanFilter::default()).await?;
 
     let deadline = Instant::now() + timeout;
     let mut found: Vec<Discovered> = Vec::new();
@@ -65,13 +114,10 @@ pub async fn scan(name_contains: &str, timeout: Duration) -> Result<Vec<Discover
             let Some(props) = p.properties().await? else {
                 continue;
             };
-            if !props.services.contains(&protocol::OURA_SERVICE) {
+            if !props_match_oura(&props, name_contains) {
                 continue;
             }
             let name = props.local_name.unwrap_or_default();
-            if !name.to_lowercase().contains(&name_contains.to_lowercase()) {
-                continue;
-            }
             let id = p.id().to_string();
             let entry = Discovered {
                 id: id.clone(),
@@ -99,11 +145,7 @@ impl BleTransport {
         scan_timeout: Duration,
     ) -> Result<Self> {
         let adapter = first_adapter().await?;
-        adapter
-            .start_scan(ScanFilter {
-                services: vec![protocol::OURA_SERVICE],
-            })
-            .await?;
+        adapter.start_scan(ScanFilter::default()).await?;
 
         let deadline = Instant::now() + scan_timeout;
         let mut chosen: Option<(Peripheral, i16)> = None;
@@ -113,11 +155,7 @@ impl BleTransport {
                 let Some(props) = p.properties().await? else {
                     continue;
                 };
-                if !props.services.contains(&protocol::OURA_SERVICE) {
-                    continue;
-                }
-                let name = props.local_name.unwrap_or_default();
-                if !name.to_lowercase().contains(&name_contains.to_lowercase()) {
+                if !props_match_oura(&props, name_contains) {
                     continue;
                 }
                 if let Some(addr) = address {
@@ -139,6 +177,22 @@ impl BleTransport {
         let _ = adapter.stop_scan().await;
 
         let (peripheral, _) = chosen.ok_or(Error::DeviceNotFound)?;
+
+        // Windows: OS BLE bond/link-encryption is required before encrypted GATT
+        // characteristics can be used. Settings UI pairing often fails; request
+        // the bond via WinRT before btleplug opens the ATT session. Bound so a
+        // stalled OS ceremony cannot hang connect forever (prompts need headroom
+        // beyond the GATT CONNECT_TIMEOUT).
+        #[cfg(windows)]
+        {
+            // Must exceed windows_bond's worst case: optional 15s stale unpair +
+            // 2×45s PairAsync attempts + up to 2×15s weak-bond unpairs + device open.
+            const BOND_TIMEOUT: Duration = Duration::from_secs(180);
+            let id = peripheral.id().to_string();
+            tokio::time::timeout(BOND_TIMEOUT, crate::windows_bond::ensure_ble_bond(&id))
+                .await
+                .map_err(|_| Error::ConnectTimeout)??;
+        }
 
         // CoreBluetooth's connect (and, on some stacks, service discovery) has no
         // deadline of its own: a ring that advertises but won't complete the GATT
@@ -209,5 +263,52 @@ impl Transport for BleTransport {
 
     fn subscribe(&self) -> broadcast::Receiver<Vec<u8>> {
         self.tx.subscribe()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn accepts_service_uuid() {
+        assert!(is_oura_advertisement(
+            &[protocol::OURA_SERVICE],
+            &HashMap::new(),
+            ""
+        ));
+    }
+
+    #[test]
+    fn accepts_oura_company_id_without_service_list() {
+        let mut mfr = HashMap::new();
+        mfr.insert(OURA_COMPANY_ID, vec![0x04, 0x40, 0x5c, 0x06]);
+        assert!(is_oura_advertisement(&[], &mfr, ""));
+    }
+
+    #[test]
+    fn name_alone_is_not_enough() {
+        assert!(!is_oura_advertisement(
+            &[],
+            &HashMap::new(),
+            "Oura Ring Gen3"
+        ));
+        assert!(!is_oura_advertisement(&[], &HashMap::new(), "courageous"));
+    }
+
+    #[test]
+    fn empty_name_needle_matches_everything() {
+        assert!(name_filter_matches("", ""));
+        assert!(name_filter_matches("", "Oura Ring Gen3"));
+        assert!(name_filter_matches("  ", "x"));
+    }
+
+    #[test]
+    fn oura_needle_allows_empty_winrt_name() {
+        assert!(name_filter_matches("Oura", ""));
+        assert!(name_filter_matches("oura", "Oura 2H4C…"));
+        assert!(!name_filter_matches("Gen3", ""));
+        assert!(name_filter_matches("Gen3", "Oura Ring Gen3"));
     }
 }

--- a/crates/oura-link/src/lib.rs
+++ b/crates/oura-link/src/lib.rs
@@ -9,6 +9,8 @@ pub mod client;
 pub mod error;
 mod history;
 pub mod transport;
+#[cfg(all(windows, feature = "ble"))]
+mod windows_bond;
 
 pub use client::OuraClient;
 pub use error::{Error, Result};

--- a/crates/oura-link/src/windows_bond.rs
+++ b/crates/oura-link/src/windows_bond.rs
@@ -1,0 +1,303 @@
+//! Windows OS-level BLE bonding (link encryption) via WinRT custom PairAsync.
+//!
+//! Factory-reset Oura rings require encrypted ATT before notify/write. On
+//! Windows, Settings UI pairing often fails; requesting a bond through
+//! `DeviceInformationCustomPairing` before GATT access is the reliable path.
+
+use crate::error::{Error, Result};
+use std::future::IntoFuture;
+use std::time::Duration;
+use windows::core::{HSTRING, Ref};
+use windows::Devices::Bluetooth::BluetoothLEDevice;
+use windows::Devices::Enumeration::{
+    DeviceInformationCustomPairing, DeviceInformationPairing, DevicePairingKinds,
+    DevicePairingProtectionLevel, DevicePairingRequestedEventArgs, DevicePairingResult,
+    DevicePairingResultStatus, DeviceUnpairingResultStatus,
+};
+use windows::Foundation::TypedEventHandler;
+
+/// Parse a btleplug Windows peripheral id (`AA:BB:CC:DD:EE:FF`) into a WinRT
+/// Bluetooth address integer. Never logs the address.
+fn bluetooth_address_from_id(peripheral_id: &str) -> Result<u64> {
+    let hex: String = peripheral_id
+        .chars()
+        .filter(|c| c.is_ascii_hexdigit())
+        .collect();
+    if hex.len() != 12 {
+        return Err(Error::Ble(
+            "windows bond: peripheral id is not a 6-byte BLE address".into(),
+        ));
+    }
+    u64::from_str_radix(&hex, 16)
+        .map_err(|_| Error::Ble("windows bond: invalid BLE address hex".into()))
+}
+
+fn status_name(status: DevicePairingResultStatus) -> &'static str {
+    match status {
+        DevicePairingResultStatus::Paired => "Paired",
+        DevicePairingResultStatus::NotReadyToPair => "NotReadyToPair",
+        DevicePairingResultStatus::NotPaired => "NotPaired",
+        DevicePairingResultStatus::AlreadyPaired => "AlreadyPaired",
+        DevicePairingResultStatus::ConnectionRejected => "ConnectionRejected",
+        DevicePairingResultStatus::TooManyConnections => "TooManyConnections",
+        DevicePairingResultStatus::HardwareFailure => "HardwareFailure",
+        DevicePairingResultStatus::AuthenticationTimeout => "AuthenticationTimeout",
+        DevicePairingResultStatus::AuthenticationNotAllowed => "AuthenticationNotAllowed",
+        DevicePairingResultStatus::AuthenticationFailure => "AuthenticationFailure",
+        DevicePairingResultStatus::NoSupportedProfiles => "NoSupportedProfiles",
+        DevicePairingResultStatus::ProtectionLevelCouldNotBeMet => "ProtectionLevelCouldNotBeMet",
+        DevicePairingResultStatus::AccessDenied => "AccessDenied",
+        DevicePairingResultStatus::InvalidCeremonyData => "InvalidCeremonyData",
+        DevicePairingResultStatus::PairingCanceled => "PairingCanceled",
+        DevicePairingResultStatus::OperationAlreadyInProgress => "OperationAlreadyInProgress",
+        DevicePairingResultStatus::RequiredHandlerNotRegistered => {
+            "RequiredHandlerNotRegistered"
+        }
+        DevicePairingResultStatus::RejectedByHandler => "RejectedByHandler",
+        DevicePairingResultStatus::RemoteDeviceHasAssociation => "RemoteDeviceHasAssociation",
+        DevicePairingResultStatus::Failed => "Failed",
+        _ => "Unknown",
+    }
+}
+
+fn level_name(level: DevicePairingProtectionLevel) -> &'static str {
+    match level {
+        DevicePairingProtectionLevel::Default => "Default",
+        DevicePairingProtectionLevel::None => "None",
+        DevicePairingProtectionLevel::Encryption => "Encryption",
+        DevicePairingProtectionLevel::EncryptionAndAuthentication => {
+            "EncryptionAndAuthentication"
+        }
+        _ => "Unknown",
+    }
+}
+
+fn is_encrypted(level: DevicePairingProtectionLevel) -> bool {
+    level == DevicePairingProtectionLevel::Encryption
+        || level == DevicePairingProtectionLevel::EncryptionAndAuthentication
+}
+
+fn pairing_kinds() -> DevicePairingKinds {
+    DevicePairingKinds::ConfirmOnly
+        | DevicePairingKinds::DisplayPin
+        | DevicePairingKinds::ProvidePin
+        | DevicePairingKinds::ConfirmPinMatch
+}
+
+async fn unpair_with_timeout(
+    pairing: &DeviceInformationPairing,
+    timeout: Duration,
+) -> Result<()> {
+    let op = pairing
+        .UnpairAsync()
+        .map_err(|e| Error::Ble(format!("windows bond: UnpairAsync start failed: {e}")))?;
+    let cancel_handle = op.clone();
+    let unpair = match tokio::time::timeout(timeout, op.into_future()).await {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => {
+            return Err(Error::Ble(format!("windows bond: UnpairAsync failed: {e}")));
+        }
+        Err(_elapsed) => {
+            let _ = cancel_handle.Cancel();
+            return Err(Error::Ble(
+                "windows bond: UnpairAsync timed out (OS ceremony cancelled)".into(),
+            ));
+        }
+    };
+    let ustatus = unpair
+        .Status()
+        .map_err(|e| Error::Ble(format!("windows bond: UnpairAsync status failed: {e}")))?;
+    if ustatus != DeviceUnpairingResultStatus::Unpaired
+        && ustatus != DeviceUnpairingResultStatus::AlreadyUnpaired
+    {
+        return Err(Error::Ble(format!(
+            "windows bond: UnpairAsync status={}",
+            match ustatus {
+                DeviceUnpairingResultStatus::OperationAlreadyInProgress => {
+                    "OperationAlreadyInProgress"
+                }
+                DeviceUnpairingResultStatus::AccessDenied => "AccessDenied",
+                DeviceUnpairingResultStatus::Failed => "Failed",
+                _ => "Unknown",
+            }
+        )));
+    }
+    Ok(())
+}
+
+fn achieved_protection(
+    result: &DevicePairingResult,
+    pairing: &windows::Devices::Enumeration::DeviceInformationPairing,
+) -> Result<DevicePairingProtectionLevel> {
+    // Prefer the result's ProtectionLevelUsed; fall back to the association's
+    // current ProtectionLevel if the result does not expose one.
+    if let Ok(used) = result.ProtectionLevelUsed() {
+        if used != DevicePairingProtectionLevel::Default {
+            return Ok(used);
+        }
+    }
+    pairing
+        .ProtectionLevel()
+        .map_err(|e| Error::Ble(format!("windows bond: ProtectionLevel failed: {e}")))
+}
+
+/// Ensure the OS has a BLE bond with encryption for `peripheral_id`.
+///
+/// Uses custom pairing with a PairingRequested handler (required on Windows for
+/// Just Works / confirm-only BLE bonds). Does not print addresses or names.
+/// Only Encryption / EncryptionAndAuthentication bonds are accepted.
+pub async fn ensure_ble_bond(peripheral_id: &str) -> Result<()> {
+    let address = bluetooth_address_from_id(peripheral_id)?;
+    let kinds = pairing_kinds();
+
+    // Helps console hosts receive inbound pairing ceremonies.
+    let _ = DeviceInformationPairing::TryRegisterForAllInboundPairingRequests(kinds);
+
+    let device = BluetoothLEDevice::FromBluetoothAddressAsync(address)
+        .map_err(|e| Error::Ble(format!("windows bond: open LE device failed: {e}")))?
+        .into_future()
+        .await
+        .map_err(|e| Error::Ble(format!("windows bond: open LE device failed: {e}")))?;
+
+    let info = device
+        .DeviceInformation()
+        .map_err(|e| Error::Ble(format!("windows bond: DeviceInformation failed: {e}")))?;
+    let pairing = info
+        .Pairing()
+        .map_err(|e| Error::Ble(format!("windows bond: Pairing API failed: {e}")))?;
+
+    if pairing
+        .IsPaired()
+        .map_err(|e| Error::Ble(format!("windows bond: IsPaired failed: {e}")))?
+    {
+        let level = pairing
+            .ProtectionLevel()
+            .map_err(|e| Error::Ble(format!("windows bond: ProtectionLevel failed: {e}")))?;
+        // Stale Settings pairings can report IsPaired with Default/None and still
+        // fail encrypted GATT. Require at least Encryption.
+        if is_encrypted(level) {
+            let _ = device.Close();
+            return Ok(());
+        }
+        eprintln!(
+            "Existing Windows pairing lacks encryption (level={}); re-pairing...",
+            level_name(level)
+        );
+        if let Err(e) = unpair_with_timeout(&pairing, Duration::from_secs(15)).await {
+            let _ = device.Close();
+            return Err(e);
+        }
+    }
+
+    if !pairing
+        .CanPair()
+        .map_err(|e| Error::Ble(format!("windows bond: CanPair failed: {e}")))?
+    {
+        let _ = device.Close();
+        return Err(Error::Ble(
+            "windows bond: device reports CanPair=false".into(),
+        ));
+    }
+
+    let custom = pairing
+        .Custom()
+        .map_err(|e| Error::Ble(format!("windows bond: Custom pairing API failed: {e}")))?;
+
+    let handler = TypedEventHandler::new(
+        move |_sender: Ref<DeviceInformationCustomPairing>,
+              args: Ref<DevicePairingRequestedEventArgs>| {
+            if let Ok(args) = args.ok() {
+                let kind = args.PairingKind()?;
+                if kind == DevicePairingKinds::ConfirmOnly
+                    || kind == DevicePairingKinds::DisplayPin
+                    || kind == DevicePairingKinds::ConfirmPinMatch
+                {
+                    args.Accept()?;
+                } else if kind == DevicePairingKinds::ProvidePin {
+                    // Common Just Works fallback when the peer asks for a PIN.
+                    args.AcceptWithPin(&HSTRING::from("0000"))?;
+                }
+            }
+            Ok(())
+        },
+    );
+    let token = custom
+        .PairingRequested(&handler)
+        .map_err(|e| Error::Ble(format!("windows bond: PairingRequested register failed: {e}")))?;
+
+    eprintln!("Requesting Windows BLE bond (approve any OS prompt)...");
+
+    // Never fall back to Default/None: those associations report Paired but do
+    // not satisfy encrypted GATT the ring requires.
+    let levels = [
+        DevicePairingProtectionLevel::Encryption,
+        DevicePairingProtectionLevel::EncryptionAndAuthentication,
+    ];
+
+    // Per-attempt budget so a hung OS ceremony is Cancel()'d rather than only
+    // dropping the Rust future (which would leave PairAsync running).
+    const PAIR_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(45);
+
+    let mut last = DevicePairingResultStatus::Failed;
+    for level in levels {
+        let op = custom
+            .PairWithProtectionLevelAsync(kinds, level)
+            .map_err(|e| Error::Ble(format!("windows bond: PairAsync start failed: {e}")))?;
+        let cancel_handle = op.clone();
+        let result = match tokio::time::timeout(PAIR_ATTEMPT_TIMEOUT, op.into_future()).await {
+            Ok(Ok(r)) => r,
+            Ok(Err(e)) => {
+                let _ = custom.RemovePairingRequested(token);
+                let _ = device.Close();
+                return Err(Error::Ble(format!("windows bond: PairAsync failed: {e}")));
+            }
+            Err(_elapsed) => {
+                // Cancel the WinRT op — dropping the future alone leaves the OS
+                // pairing ceremony running and can race the next attempt.
+                let _ = cancel_handle.Cancel();
+                let _ = custom.RemovePairingRequested(token);
+                let _ = device.Close();
+                return Err(Error::Ble(
+                    "windows bond: PairAsync timed out (OS ceremony cancelled)".into(),
+                ));
+            }
+        };
+        last = result
+            .Status()
+            .map_err(|e| Error::Ble(format!("windows bond: PairAsync status failed: {e}")))?;
+        if last == DevicePairingResultStatus::Paired
+            || last == DevicePairingResultStatus::AlreadyPaired
+        {
+            let used = achieved_protection(&result, &pairing)?;
+            if is_encrypted(used) {
+                let _ = custom.RemovePairingRequested(token);
+                let _ = device.Close();
+                eprintln!(
+                    "Windows BLE bond established (protection={}).",
+                    level_name(used)
+                );
+                return Ok(());
+            }
+            // Paired but weak — tear it down and keep trying stronger levels.
+            eprintln!(
+                "Windows pairing succeeded at insufficient protection ({}); retrying...",
+                level_name(used)
+            );
+            let _ = unpair_with_timeout(&pairing, Duration::from_secs(15)).await;
+            continue;
+        }
+        if last != DevicePairingResultStatus::ProtectionLevelCouldNotBeMet
+            && last != DevicePairingResultStatus::Failed
+            && last != DevicePairingResultStatus::NotReadyToPair
+        {
+            break;
+        }
+    }
+
+    let _ = custom.RemovePairingRequested(token);
+    let _ = device.Close();
+    Err(Error::Ble(format!(
+        "windows bond: PairAsync status={} (encryption required)",
+        status_name(last)
+    )))
+}


### PR DESCRIPTION
## Summary
- Windows WinRT custom `PairAsync` bond (Encryption+) before GATT, with Cancel-on-timeout and a 180s outer budget
- Replace `/dev/urandom` key minting with `getrandom`; create auth key files with current-user-only DACL (verified + unit-tested)
- Loosen BLE discovery for incomplete WinRT ads (Oura service UUID or manufacturer `0x02B2`; name alone is never enough)

## Context
Factory-reset Gen3 rings reject unencrypted ATT on Windows. Settings UI pairing is unreliable; this path bonds via `DeviceInformationCustomPairing` before `btleplug` opens the session. Intended for `open_health` / Windows collectors on `split-open-health`.

Reviewed locally (Codex + Claude). Claude final: approve-with-nits; nits fixed before push. Opening as **draft** — not claiming merge-ready without maintainer Windows hardware check.

## Test plan
- [ ] `cargo test --workspace` on Windows
- [ ] `cargo check -p oura-link --no-default-features` (iOS / no-ble)
- [ ] `oura scan` sees ring via UUID and/or mfr `0x02B2` with phone BT off
- [ ] `oura pair --key-file …` establishes Encryption+ bond and installs auth key
- [ ] Confirm key file ACL is current-user-only (single ACE)
- [ ] Non-Oura device whose name contains "oura" is not selected / bonded